### PR TITLE
Tamanash | Completed fix for OTP replay issue in Validation

### DIFF
--- a/src/main/java/com/cros/keycloak/admin/OtpAdminResource.java
+++ b/src/main/java/com/cros/keycloak/admin/OtpAdminResource.java
@@ -322,10 +322,10 @@ public class OtpAdminResource {
                 String searchKey = var10000 + "." + code;
 
                 if(singleUseStore.contains(searchKey)) {
-                    LOG.infof("Store contains key: %s", searchKey);
+                    // LOG.infof("Store contains key: %s", searchKey);
                     return false;
                 }
-                LOG.infof("Store does not contain key: %s", searchKey);
+                // LOG.infof("Store does not contain key: %s", searchKey);
             }           
 
             OTPPolicy policy = realm.getOTPPolicy();

--- a/src/main/java/com/cros/keycloak/rest/OtpRestResourceProvider.java
+++ b/src/main/java/com/cros/keycloak/rest/OtpRestResourceProvider.java
@@ -426,10 +426,10 @@ public class OtpRestResourceProvider implements RealmResourceProvider {
                 String searchKey = var10000 + "." + code;
 
                 if(singleUseStore.contains(searchKey)) {
-                    LOG.infof("Store contains key: %s", searchKey);
+                    // LOG.infof("Store contains key: %s", searchKey);
                     return false;
                 }
-                LOG.infof("Store does not contain key: %s", searchKey);
+                // LOG.infof("Store does not contain key: %s", searchKey);
             }           
 
             OTPPolicy policy = realm.getOTPPolicy();

--- a/src/main/java/com/cros/keycloak/rest/OtpRestResourceProvider.java
+++ b/src/main/java/com/cros/keycloak/rest/OtpRestResourceProvider.java
@@ -12,6 +12,7 @@ import org.keycloak.models.OTPPolicy;
 import org.keycloak.models.utils.Base32;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.SingleUseObjectProvider;
 import org.keycloak.models.UserCredentialModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.credential.OTPCredentialModel;
@@ -157,7 +158,7 @@ public class OtpRestResourceProvider implements RealmResourceProvider {
         OTPCredentialModel otpCredentialModel = OTPCredentialModel.createFromCredentialModel(otpData);
         // LOG.infof("Credential Data Secret : %s", otpCredentialModel.getOTPSecretData().getValue());
         
-        if (!verifyOtpCode(otpCredentialModel.getOTPSecretData().getValue(), otpCode, realm)) {
+        if (!verifyOtpCode(user, otpCode, realm, otpCredentialModel.getOTPSecretData().getValue())) {
             result.put("success", false);
             result.put("error", "INVALID_OTP");
             result.put("message", "Invalid OTP code");
@@ -254,7 +255,7 @@ public class OtpRestResourceProvider implements RealmResourceProvider {
         }
         
         // Verify the OTP code
-        if (!verifyOtpCode(pendingConfig.getRawSecret(), otpCode, realm)) {
+        if (!verifyOtpCode(user, otpCode, realm, pendingConfig.getRawSecret())) {
             Map<String, String> error = new HashMap<>();
             error.put("error", "Invalid OTP code");
             return Response.status(Response.Status.BAD_REQUEST).entity(error).build();
@@ -412,17 +413,49 @@ public class OtpRestResourceProvider implements RealmResourceProvider {
         }
     }
     
-    private boolean verifyOtpCode(String secret, String code, RealmModel realm) {
+    private boolean verifyOtpCode(UserModel user, String code, RealmModel realm, String secret) {        
         try {
+            boolean isConfigured = user.credentialManager()
+                .getStoredCredentialsByTypeStream(OTPCredentialModel.TYPE).findFirst().isPresent();
+            
+            if(isConfigured){
+                CredentialModel otpData = user.credentialManager().getStoredCredentialsByTypeStream(OTPCredentialModel.TYPE).findFirst().get();
+
+                SingleUseObjectProvider singleUseStore = this.session.singleUseObjects();
+                String var10000 = otpData.getId();
+                String searchKey = var10000 + "." + code;
+
+                if(singleUseStore.contains(searchKey)) {
+                    LOG.infof("Store contains key: %s", searchKey);
+                    return false;
+                }
+                LOG.infof("Store does not contain key: %s", searchKey);
+            }           
+
             OTPPolicy policy = realm.getOTPPolicy();
-            TimeBasedOTP totp = new TimeBasedOTP(
-                policy.getAlgorithm(),
-                policy.getDigits(),
-                policy.getPeriod(),
+            TimeBasedOTP validator = new TimeBasedOTP(
+                policy.getAlgorithm(), 
+                policy.getDigits(), 
+                policy.getPeriod(), 
                 policy.getLookAheadWindow()
             );
+
+            return validator.validateTOTP(code, secret.getBytes());             
             
-            return totp.validateTOTP(code, secret.getBytes());
+            /* 
+            // Validate OTP - Consumes OTP so it cannot be used again
+            OTPCredentialProvider otpProvider = (OTPCredentialProvider) session.getProvider(
+            CredentialProvider.class, OTPCredentialProviderFactory.PROVIDER_ID);
+
+            CredentialModel otpData = user.credentialManager()
+                .getStoredCredentialsByTypeStream(OTPCredentialModel.TYPE).findFirst().get();
+
+            OTPCredentialModel otpCredentialModel = OTPCredentialModel.createFromCredentialModel(otpData);
+            CredentialInput otpInput = new UserCredentialModel(otpCredentialModel.getId(), OTPCredentialModel.TOTP, code);
+            LOG.infof("ID found: %s", otpInput.getCredentialId());
+
+            return otpProvider.isValid(realm, user, otpInput); 
+            */
         } catch (Exception e) {
             LOG.error("Error verifying OTP code", e);
             return false;


### PR DESCRIPTION
Fixes issue in `verifyOtpCode` function where if trying to validate a consumed otp the response returned was success.
Now, the function checks the SingleUseStore utilized by keycloak to validate alrady consumed OTP's.